### PR TITLE
Chore: split the pre-commit and go-lint actions

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,0 +1,55 @@
+# These github actions will perform linting and go tests
+# spell-checker: disable
+---
+name: go-lint
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  go-mod-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: v2/go.mod
+          cache: true
+      - name: Verify go.mod and go.sum are up to date
+        run: cd v2 && go mod tidy && git diff --exit-code -- go.mod go.sum
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: v2/go.mod
+          cache: true
+      - name: Execute linter
+        uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          version: latest
+          args: ./v2/...
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: v2/go.mod
+          cache: true
+      - name: Run go tests
+        run: go test -v -short ./v2/...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install talisman
         run: |
-          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.28.0/talisman_linux_amd64
+          sudo curl -sLo /usr/local/bin/talisman https://github.com/thoughtworks/talisman/releases/download/v1.29.1/talisman_linux_amd64
           sudo chmod 0755 /usr/local/bin/talisman
       - name: Install Python
         uses: actions/setup-python@v4
@@ -39,35 +39,3 @@ jobs:
         uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: "Dockerfile"
-  golangci-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Execute linter
-        uses: golangci/golangci-lint-action@v3.2.0
-        with:
-          version: latest
-          args: ./v2/...
-  go-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - name: Cache packages
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('v2/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Run go tests
-        run: go test -v -short ./v2/...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # spell-checker:disable
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.27.1
+    rev: v1.28.0
     hooks:
       - id: yamllint
         files: \.(yml|yaml|talismanrc)$
@@ -18,6 +18,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/thoughtworks/talisman
-    rev: v1.28.0
+    rev: v1.29.1
     hooks:
       - id: talisman-commit


### PR DESCRIPTION
This is to be consistent with other Go projects in memes.