### PR TITLE
ci: golangci-lint cfg exportloopref=>copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     - decorder
     - depguard
     - dogsled
@@ -31,7 +32,6 @@ linters:
     - exhaustive
     # NOTE: Too noisy in this repo
     # - exhaustruct
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - funlen


### PR DESCRIPTION
The exportloopref linter is deprecated in golangci-lint 1.60.3, with a recommendation to replace with copyloopvar linter.