### PR TITLE
fix: Prefer int64 over uint64 to reduce casting

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -49,7 +49,7 @@ fileignoreconfig:
 - filename: v2/supporting/otel-collector-config.yaml
   checksum: 9afb13648fe8cfa21e60bfba80cb4ca1afb2b9350eac74009e4770adf9a55ae9
 - filename: v2/pkg/server/server.go
-  checksum: 5d6a44561c37ff9bd4b5263f5550b49082b12a7d9dda53bb0b9d9329ede0faf7
+  checksum: 2559611e457e20b52ab944d93fc61f263aada7db860e05831c43c3e866afe19c
 - filename: v2/cmd/pi/otel.go
   checksum: d1f8dca16ab3a8e6c0c328a20665be5cea8ba81bc627ad648f59e287264d29f9
 - filename: v2/supporting/kustomization.yaml

--- a/v2/pi.go
+++ b/v2/pi.go
@@ -107,7 +107,7 @@ func FindNextPrime(n int64) int64 {
 // fractional decimal digits of pi at the specified zero-based offset.
 //
 //nolint:funlen // The algorithm is what it is
-func BBPDigits(n uint64) string {
+func BBPDigits(n int64) string {
 	logger := Logger.V(1).WithValues("n", n)
 	logger.Info("BBPDigits: enter")
 	N := int64(float64(n+21) * math.Log(10) / math.Log(2))
@@ -166,7 +166,7 @@ func BBPDigits(n uint64) string {
 			}
 		}
 
-		t = powMod(10, int64(n), av)
+		t = powMod(10, n, av)
 		s = (s * t) % av
 		sum = math.Mod(sum+float64(s)/float64(av), 1.0)
 	}

--- a/v2/pi_test.go
+++ b/v2/pi_test.go
@@ -1246,7 +1246,7 @@ var (
 )
 
 // Helper to verify that BBPDigits returns digits that meet the expected digits of pi.
-func testBBPDigits(t *testing.T, index uint64) {
+func testBBPDigits(t *testing.T, index int64) {
 	t.Helper()
 	expected := PiDigits[index : index+9]
 	if actual := pi.BBPDigits(index); actual != expected {
@@ -1263,7 +1263,7 @@ func TestBBPDigits(t *testing.T) {
 	}
 	t.Parallel()
 	for i := 0; i < maxDigits; i += 9 {
-		index := uint64(i)
+		index := int64(i)
 		t.Run(fmt.Sprintf("index=%d", index), func(t *testing.T) {
 			testBBPDigits(t, index)
 		})
@@ -1271,7 +1271,7 @@ func TestBBPDigits(t *testing.T) {
 }
 
 // Helper to benchmark calculation of pi digits index through index+8, inclusive.
-func benchmarkBBPDigits(b *testing.B, index uint64) {
+func benchmarkBBPDigits(b *testing.B, index int64) {
 	b.Helper()
 	for i := 0; i < b.N; i++ {
 		_ = pi.BBPDigits(index)
@@ -1281,7 +1281,7 @@ func benchmarkBBPDigits(b *testing.B, index uint64) {
 // Benchmark calculating pi digits.
 func BenchmarkBBPDigits(b *testing.B) {
 	for exp := 0; exp <= BenchmarkPiDigitExponentLimit; exp++ {
-		index := uint64(math.Pow10(exp))
+		index := int64(math.Pow10(exp))
 		b.Run(fmt.Sprintf("index=%d", index), func(b *testing.B) {
 			benchmarkBBPDigits(b, index)
 		})
@@ -1346,7 +1346,7 @@ func Example() {
 func ExampleBBPDigits() {
 	// Print the first 100 digits of pi using a default calculator
 	fmt.Printf("The first 100 digits of pi are: 3.")
-	for n := uint64(0); n < 99; n += 9 {
+	for n := int64(0); n < 99; n += 9 {
 		fmt.Print(pi.BBPDigits(n))
 	}
 	fmt.Println()

--- a/v2/pkg/client/client.go
+++ b/v2/pkg/client/client.go
@@ -161,7 +161,7 @@ func (c *PiClient) FetchDigit(ctx context.Context, index uint64) (uint32, error)
 	logger := c.logger.V(1).WithValues("index", index)
 	logger.Info("Starting connection to service")
 	attributes := []attribute.KeyValue{
-		attribute.Int(OpenTelemetryPackageIdentifier+".index", int(index)),
+		attribute.Int64(OpenTelemetryPackageIdentifier+".index", int64(index)), //nolint:gosec // Don't care if there is an overflow here
 	}
 	ctx, span := otel.Tracer(OpenTelemetryPackageIdentifier).Start(ctx, OpenTelemetryPackageIdentifier+"/FetchDigit")
 	defer span.End()

--- a/v2/pkg/server/server_test.go
+++ b/v2/pkg/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestGetDigit_WithNoopCache(t *testing.T) {
 	}
 }
 
-func TestFractionalDigit_WithRedisCache(t *testing.T) {
+func TestGetDigit_WithRedisCache(t *testing.T) {
 	ctx := context.Background()
 	mock, err := miniredis.Run()
 	if err != nil {
@@ -73,5 +74,21 @@ func TestFractionalDigit_WithRedisCache(t *testing.T) {
 				Index: uint64(index),
 			}, piServer)
 		})
+	}
+}
+
+// Verify that setting uint index to a number larger than supported by int64 will return an error.
+func TestGetDigit_Overflow(t *testing.T) {
+	ctx := context.Background()
+	t.Parallel()
+	piServer, err := server.NewPiServer()
+	if err != nil {
+		t.Errorf("Error calling NewPiServer: %v", err)
+	}
+	_, err = piServer.GetDigit(ctx, &generated.GetDigitRequest{
+		Index: uint64(math.MaxInt64) + 1,
+	})
+	if err == nil {
+		t.Error("expected GetDigit to return an error, but didn't")
 	}
 }


### PR DESCRIPTION
It was probably a big mistake to use uints in v2 protobuf declaration, as most of the math requires ints and OTEL for go only supports ints.

This change deals with the uint/int conversion in FetchDigit functions and will return an error if a uint index is provided that can't be cast as an int without overflowing.