### PR TITLE
fix: suppress int/uint64/uint32 gosec warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - memes
   - package-ecosystem: "gomod"
     directory: "/v2"
     schedule:

--- a/v2/cmd/pi/client.go
+++ b/v2/cmd/pi/client.go
@@ -121,7 +121,7 @@ func clientMain(_ *cobra.Command, endpoints []string) error {
 			if err = collator(idx, digit); err != nil {
 				logger.Error(err, "Error calling collator", "idx", idx, "digit", digit)
 			}
-		}(uint64(index))
+		}(uint64(index)) //nolint:gosec // Risk of overflow is low
 	}
 	wg.Wait()
 	return nil

--- a/v2/pkg/server/server.go
+++ b/v2/pkg/server/server.go
@@ -247,7 +247,7 @@ func (s *PiServer) GetDigit(ctx context.Context, in *generated.GetDigitRequest) 
 	logger.Info("GetDigit: exit", "digit", digit)
 	return &generated.GetDigitResponse{
 		Index:    in.Index,
-		Digit:    uint32(digit), //nolint:gosec // digit will always be between 0 and 9 inclusive, no risk of overflow
+		Digit:    uint32(digit),
 		Metadata: s.metadata,
 	}, nil
 }

--- a/v2/pkg/server/server_test.go
+++ b/v2/pkg/server/server_test.go
@@ -47,7 +47,7 @@ func TestGetDigit_WithNoopCache(t *testing.T) {
 	for index := 0; index < len(PiDigits); index++ {
 		t.Run(fmt.Sprintf("index=%d", index), func(t *testing.T) {
 			testGetDigit(ctx, t, &generated.GetDigitRequest{
-				Index: uint64(index),
+				Index: uint64(index), //nolint:gosec // Risk of overflow is low
 			}, piServer)
 		})
 	}
@@ -71,7 +71,7 @@ func TestGetDigit_WithRedisCache(t *testing.T) {
 	for index := 0; index < len(PiDigits); index++ {
 		t.Run(fmt.Sprintf("index=%d", index), func(t *testing.T) {
 			testGetDigit(ctx, t, &generated.GetDigitRequest{
-				Index: uint64(index),
+				Index: uint64(index), //nolint:gosec // Risk of overflow is low
 			}, piServer)
 		})
 	}


### PR DESCRIPTION
Another round of nolint comments to suppress gosec warnings about int conversions to/from uint.

Remind me never to declare uint type in protobuf again :)