### PR TITLE
fix: Don't build 32bit binaries

### DIFF
--- a/v2/.goreleaser.yml
+++ b/v2/.goreleaser.yml
@@ -17,12 +17,10 @@ builds:
       - darwin
     goarch:
       - amd64
-      - '386'
       - arm
       - arm64
     ignore:
-      - goos: darwin
-        goarch: '386'
+      - goarm: 6
     main: ./cmd/pi/
     mod_timestamp: '{{ .CommitTimestamp }}'
 gomod:


### PR DESCRIPTION
Since the API exposes indexes as uint64's the 32bit versions should not be used. This change limits the goreleaser builds to 64bit.