### PR TITLE
Fix gosec overflow issues

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -58,7 +58,7 @@ fileignoreconfig:
 - filename: v2/supporting/otel-all-in-one.yaml
   checksum: 897e58b3dc0459284fab25c88eb458455f9cad54d571f7ffcc2ebd7851ac8e5a
 - filename: go.work.sum
-  checksum: 668cfce097f579e7bd03cb18031cfbc4901e10a4d57be5339d50a6b22a4e50a0
+  checksum: a0de343159387ceee0df2efbf95946f38456842d7f9435d2a5bc65c8e436767a
   ignore_detectors: []
 - filename: .github/workflows/pre-commit.yml
   checksum: fd775abf705cfa74ab16bb6807fe36cbaa9950758a79ce3017752eb708d46588

--- a/go.work.sum
+++ b/go.work.sum
@@ -580,6 +580,7 @@ golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/mod v0.30.0/go.mod h1:lAsf5O2EvJeSFMiBxXDki7sCgAxEUcZHXoXMKT4GJKc=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
@@ -657,6 +658,7 @@ golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0
 golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/tools v0.39.0/go.mod h1:JnefbkDPyD8UU2kI5fuf8ZX4/yUeh9W877ZeBONxUqQ=
+golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/v2/cmd/pi/collate.go
+++ b/v2/cmd/pi/collate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func collateMain(cmd *cobra.Command, endpoints []string) error {
 	}
 	// Set the global collator function to add digits to the array
 	collator = func(index uint64, value uint32) error {
-		digits[index] = '0' + byte(value)
+		digits[index] = '0' + byte(value&math.MaxUint8)
 		return nil
 	}
 	if err := clientMain(cmd, endpoints); err != nil {

--- a/v2/pkg/server/server.go
+++ b/v2/pkg/server/server.go
@@ -194,7 +194,7 @@ func WithRestClientAuthority(restClientAuthority string) PiServerOption {
 func (s *PiServer) GetDigit(ctx context.Context, in *generated.GetDigitRequest) (*generated.GetDigitResponse, error) {
 	logger := s.logger.WithValues("index", in.Index)
 	logger.Info("GetDigit: enter")
-	index := int64(in.Index)
+	index := int64(in.Index & math.MaxInt64)
 	cacheIndex := (index / 9) * 9
 	key := strconv.FormatInt(cacheIndex, 16)
 	attributes := []attribute.KeyValue{


### PR DESCRIPTION
Add guards to address potential overflows as raised by gosec during linting.
* collate.go: Mask to 0xff to get just the least significant byte from value; the value will always be between 0 and 9 anyway.
* server.go: Mask cast from uint64 to int64; line 207 raises an error anyway if the value would have been an overflow.